### PR TITLE
Add interactive study plan page

### DIFF
--- a/src/main/webapp/study-plan.html
+++ b/src/main/webapp/study-plan.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Generador de Estrategias de Estudio 2025</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
+</head>
+<body class="p-4">
+  <h1 class="mb-4">Generador de Estrategias de Estudio 2025</h1>
+  <div class="mb-3">
+    <label for="topicInput" class="form-label">Tema principal</label>
+    <input id="topicInput" class="form-control" />
+  </div>
+  <div class="mb-3">
+    <label for="subtopicsInput" class="form-label">Subtemas (separados por comas)</label>
+    <textarea id="subtopicsInput" class="form-control" rows="3"></textarea>
+  </div>
+  <button class="btn btn-primary" onclick="generateStudyPlan()">Generar plan</button>
+
+  <div id="results" class="mt-4" style="display:none;">
+    <h2 id="topicTitle"></h2>
+    <h4>Subtemas</h4>
+    <ul id="subtopicList"></ul>
+
+    <h4>Mapa mental</h4>
+    <div id="mindmap" class="mb-3"></div>
+
+    <h4>Tarjetas de estudio</h4>
+    <div id="flashcards" class="mb-3"></div>
+
+    <h4>Sesiones sugeridas</h4>
+    <div id="sessions" class="mb-3"></div>
+
+    <h4>Cronograma</h4>
+    <div id="timeline"></div>
+  </div>
+
+  <script>
+  function generateStudyPlan(){
+    const topic = document.getElementById('topicInput').value.trim();
+    const subtopics = document.getElementById('subtopicsInput').value.split(',').map(s=>s.trim()).filter(Boolean);
+    if(!topic){alert('Ingresa un tema');return;}
+    document.getElementById('results').style.display='block';
+    document.getElementById('topicTitle').textContent = topic;
+    renderSubtopics(subtopics);
+    generateMindmap(topic, subtopics);
+    generateFlashcards(topic, subtopics);
+    generateSessions(topic, subtopics);
+    generateTimeline(topic);
+  }
+
+  function renderSubtopics(subtopics){
+    const list = document.getElementById('subtopicList');
+    list.innerHTML='';
+    subtopics.forEach(s=>{const li=document.createElement('li');li.textContent=s;list.appendChild(li);});
+  }
+
+  function generateMindmap(topic, subtopics){
+    const map=document.getElementById('mindmap');
+    map.innerHTML=`<strong>${topic}</strong>`;
+    const ul=document.createElement('ul');
+    subtopics.forEach(s=>{const li=document.createElement('li');li.textContent=s;ul.appendChild(li);});
+    map.appendChild(ul);
+  }
+
+  function generateFlashcards(topic, subtopics){
+    const container=document.getElementById('flashcards');
+    container.innerHTML='';
+    const cards=[{front:`¿Qué es ${topic}?`,back:`${topic} es un concepto clave en los estudios sociales.`}];
+    if(subtopics.length){cards.push({front:'Subtemas',back:subtopics.join(', ')});}
+    cards.forEach(c=>{
+      const div=document.createElement('div');
+      div.className='card p-2 my-2';
+      div.textContent=c.front;
+      div.onclick=()=>{div.textContent=div.textContent===c.front?c.back:c.front;};
+      container.appendChild(div);
+    });
+  }
+
+  function generateSessions(topic, subtopics){
+    const container=document.getElementById('sessions');
+    container.innerHTML='';
+    const sessions=[
+      `Repasar fundamentos de ${topic}`,
+      subtopics[0]?`Profundizar en ${subtopics[0]}`:'Analizar estudios de caso',
+      subtopics[1]?`Comparar con ${subtopics[1]}`:'Repaso general'
+    ];
+    const ul=document.createElement('ul');
+    sessions.forEach((s,i)=>{const li=document.createElement('li');li.textContent=`Sesión ${i+1}: ${s}`;ul.appendChild(li);});
+    container.appendChild(ul);
+  }
+
+  function generateTimeline(topic){
+    const container=document.getElementById('timeline');
+    container.innerHTML='';
+    const days=['Explorar','Profundizar','Aplicar','Repasar','Evaluar'];
+    const ol=document.createElement('ol');
+    days.forEach((d,i)=>{const li=document.createElement('li');li.textContent=`Día ${i+1}: ${d} ${topic}`;ol.appendChild(li);});
+    container.appendChild(ol);
+  }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add study-plan.html with simple form and interactive JavaScript to generate mind map, flashcards, session schedule, and study timeline.

## Testing
- `mvn -q test` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689581de3c408330ad7ad7c24d08351f